### PR TITLE
Pass raw file to transform in case file properties matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const xmlEdit = function(transform, options) {
         const builder = new xml2js.Builder(settings.builderOptions);
 
         parser.parseString(content, function(err, data) {
-            let content = transform.call(null, data);
+            let content = transform.call(null, data, file);
 
             if (!isObject(content)) {
                 done(new PluginError('gulp-xml-edit', 'transformation does not returns an object'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
       "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-slice": "0.2.3"
+        "arr-flatten": "^1.0.1",
+        "array-slice": "^0.2.3"
       }
     },
     "arr-flatten": {
@@ -73,9 +73,9 @@
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "coffee-script": {
@@ -102,13 +102,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "extend-shallow": {
@@ -116,7 +116,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
       "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
       "requires": {
-        "kind-of": "1.1.0"
+        "kind-of": "^1.1.0"
       }
     },
     "fileset": {
@@ -125,8 +125,8 @@
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "minimatch": "0.2.14"
+        "glob": "3.x",
+        "minimatch": "0.x"
       }
     },
     "from": {
@@ -141,8 +141,8 @@
       "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
       "dev": true,
       "requires": {
-        "fileset": "0.1.8",
-        "minimatch": "0.2.14"
+        "fileset": "~0.1.5",
+        "minimatch": "~0.2.9"
       }
     },
     "glob": {
@@ -151,8 +151,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "2",
+        "minimatch": "0.3"
       },
       "dependencies": {
         "minimatch": {
@@ -161,8 +161,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -191,7 +191,7 @@
       "integrity": "sha1-uHrlUeNZ0orVIXdl6u9sB7dj9sg=",
       "dev": true,
       "requires": {
-        "growl": "1.7.0"
+        "growl": "~1.7.0"
       }
     },
     "jasmine-node": {
@@ -200,14 +200,14 @@
       "integrity": "sha1-GOg5e4VpJO53ADZmw3MbWupQw50=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.12.7",
-        "gaze": "0.3.4",
-        "jasmine-growl-reporter": "0.0.3",
-        "jasmine-reporters": "1.0.2",
-        "mkdirp": "0.3.5",
-        "requirejs": "2.3.5",
-        "underscore": "1.8.3",
-        "walkdir": "0.0.12"
+        "coffee-script": ">=1.0.1",
+        "gaze": "~0.3.2",
+        "jasmine-growl-reporter": "~0.0.2",
+        "jasmine-reporters": "~1.0.0",
+        "mkdirp": "~0.3.5",
+        "requirejs": ">=0.27.1",
+        "underscore": ">= 1.3.1",
+        "walkdir": ">= 0.0.1"
       }
     },
     "jasmine-reporters": {
@@ -216,7 +216,7 @@
       "integrity": "sha1-q2E+1Zd9x0h+hbPBL2qOqNsq3jE=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.3.5"
+        "mkdirp": "~0.3.5"
       }
     },
     "kind-of": {
@@ -252,8 +252,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "mkdirp": {
@@ -273,7 +273,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "plugin-error": {
@@ -281,11 +281,11 @@
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-red": "0.1.1",
-        "arr-diff": "1.1.0",
-        "arr-union": "2.1.0",
-        "extend-shallow": "1.1.4"
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
       }
     },
     "process-nextick-args": {
@@ -300,13 +300,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -350,7 +350,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "stream-combiner": {
@@ -359,7 +359,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "string_decoder": {
@@ -368,7 +368,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "through": {
@@ -383,8 +383,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "underscore": {
@@ -405,12 +405,12 @@
       "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "dev": true,
       "requires": {
-        "clone": "2.1.1",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.0.0",
-        "remove-trailing-separator": "1.1.0",
-        "replace-ext": "1.0.0"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "walkdir": {
@@ -424,8 +424,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {

--- a/test/edit-xml-spec.js
+++ b/test/edit-xml-spec.js
@@ -68,4 +68,40 @@ describe('gulp-xml-edit', function() {
         stream.write(fakeFile);
         stream.end();
     });
+
+    it('should pass the raw file to the transform', () => {
+        let captured = null;
+        const stream = xmlEdit((data, file) => {
+            delete data.svg.g[0].circle[0].$.transform;
+            captured = file.name;
+            return data;
+        });
+        const fakeBuffer = new Buffer(
+            "<svg><g><circle cx='20' cy='20' cr='20' transform='translate(20 20)'/></g></svg>"
+        );
+        const fakeFile = new Vinyl({
+            contents: fakeBuffer,
+            name: "expected.xml"
+        });
+        let n = 0;
+
+        stream.pipe(
+            es.through(
+                file => {
+                    expect(file.contents.toString()).toBe(
+                        '<svg><g><circle cx="20" cy="20" cr="20"/></g></svg>'
+                    );
+                    n++;
+                },
+                () => {
+                    expect(captured).not.toBe(null);
+                    expect(captured).toBe("expected.xml");
+                    done();
+                }
+            )
+        );
+
+        stream.write(fakeFile);
+        stream.end();
+    });
 });


### PR DESCRIPTION
I'm using gulp-edit-xml to increment the package version for my nuget packages before pushing to Nuget.org.

In the case where the input source is a `Package.nuspec`, the file contains all the information I need -- I can get the `version` node, and there's an `id` node which provides the package id, so I can log out, eg: `MyPackage version incremented to 1.2.3`.

When using the .csproj as the source of packing information (as is customary with `dotnet pack`, there may, or may not, be a `PackageId` node providing this name. In the case when it's not present, the assembly name or directory name for the project are used. This is where I need access to the raw Vinyl file -- to get the path to the provided XML.

This PR addresses only that: passing through the original raw Vinyl file into the transform as an optional second parameter.