### PR TITLE
fix: add index.d.ts to packagejson.files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "src",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "keywords": [
     "gulp",


### PR DESCRIPTION
This fixes the issue where typescript declarations are not available when installing from NPM